### PR TITLE
Option to use input file checksum as cache buster

### DIFF
--- a/bin/blessc
+++ b/bin/blessc
@@ -34,13 +34,14 @@ args = args.filter(function (arg) {
             console.log('Usage: blessc [options] [ source | - ] [destination]');
             console.log('');
             console.log('Options :');
-            console.log('  -v, --version      print version');
-            console.log('  -h, --help         print this help');
-            console.log('  -f, --force        overwrite input file');
-            console.log('  -x, --compress     "minify" @import');
-            console.log('  --no-cleanup       don\'t remove old css file before overwriting');
-            console.log('  --no-imports       disable @import on stylesheets');
-            console.log('  --no-cache-buster  turn off the cache buster');
+            console.log('  -v, --version         print version');
+            console.log('  -h, --help            print this help');
+            console.log('  -f, --force           overwrite input file');
+            console.log('  -x, --compress        "minify" @import');
+            console.log('  --no-cleanup          don\'t remove old css file before overwriting');
+            console.log('  --no-imports          disable @import on stylesheets');
+            console.log('  --no-cache-buster     turn off the cache buster');
+            console.log('  --cache-buster=MODE   specify cache buster mode: timestamp (default), checksum');
             console.log('');
             console.log('Full documentation can be found at http://blesscss.com/');
             process.exit(0);
@@ -60,6 +61,12 @@ args = args.filter(function (arg) {
             break;
         case 'no-cache-buster':
             options.cacheBuster = false;
+            break;
+        case 'cache-buster':
+            // Only honor if cacheBuster has not yet been disabled.
+            if (options.cacheBuster === true) {
+                options.cacheBuster = match[2] || true;
+            }
     }
 });
 

--- a/lib/bless/parser.js
+++ b/lib/bless/parser.js
@@ -3,7 +3,8 @@
 var path = require('path'),
     fs = require('fs'),
     bless = exports,
-    cacheBuster = '?z=' + new Date().getTime();
+    crypto = require('crypto'),
+    timestamp = new Date().getTime();
 
 bless.Parser = function Parser(env) {
     this.env = env = env || {};
@@ -38,7 +39,17 @@ bless.Parser = function Parser(env) {
             var ext = path.extname(output),
                 filename = path.basename(output, ext),
                 offset = 0,
-                selectorCount = 0;
+                selectorCount = 0,
+                cacheBuster = '';
+
+            if (options.cacheBuster) {
+                cacheBuster = '?z=';
+                if (options.cacheBuster == 'checksum') {
+                    cacheBuster += crypto.createHash('md5').update(str).digest('hex');
+                } else {
+                    cacheBuster += timestamp;
+                }
+            }
 
             for (var i = 0, length = rules.length; i < length; i++) {
                 var matchCount,
@@ -91,10 +102,7 @@ bless.Parser = function Parser(env) {
 
             if (filesLength > 0 && options.imports) {
                 for(var k=1; k<=filesLength; k++) {
-                    var outputFilename = filename + '-blessed' + k + ext;
-                    if (options.cacheBuster) {
-                        outputFilename += cacheBuster;
-                    }
+                    var outputFilename = filename + '-blessed' + k + ext + cacheBuster;
                     var importStr = '@import url(\'' + outputFilename + '\');';
                     importStr = options.compress ? importStr : importStr + '\n';
                     rules.unshift(importStr);
@@ -122,7 +130,7 @@ bless.Parser.cleanup = function (options, output, callback) {
         fileRegex = filename + '-blessed' + '(\\d+)' + ext;
 
     if (options.cacheBuster) {
-        fileRegex += cacheBuster;
+        fileRegex += '\?[^\']*';
     }
 
     var importRegex = '@import url\\(\'(' + fileRegex + '\')\\);';

--- a/test/output/above-limit-with-comment.css
+++ b/test/output/above-limit-with-comment.css
@@ -1,4 +1,4 @@
-@import url('above-limit-with-comment-blessed1.css');
+@import url('above-limit-with-comment-blessed1.css?z=54a6d19615cdadba8e7e7c3cd85e28d0');
 
 #test,
 #test,

--- a/test/output/above-limit.css
+++ b/test/output/above-limit.css
@@ -1,4 +1,4 @@
-@import url('above-limit-blessed2.css');
-@import url('above-limit-blessed1.css');
+@import url('above-limit-blessed2.css?z=c75b09cdde4a378204235a0c5c6e21d1');
+@import url('above-limit-blessed1.css?z=c75b09cdde4a378204235a0c5c6e21d1');
 
 #test { background-color: blue; }

--- a/test/output/media-query-one.css
+++ b/test/output/media-query-one.css
@@ -1,4 +1,4 @@
-@import url('media-query-one-blessed1.css');
+@import url('media-query-one-blessed1.css?z=17bd598459bcea0918342caf7cb34645');
 
 @media print {
     #test { color: #090; }

--- a/test/output/media-query-three.css
+++ b/test/output/media-query-three.css
@@ -1,4 +1,4 @@
-@import url('media-query-three-blessed1.css');
+@import url('media-query-three-blessed1.css?z=9e44e23e31ba3a8216a62fc276131100');
 
 @media screen and (max-device-width: 480px) {
     #test,

--- a/test/output/media-query-two.css
+++ b/test/output/media-query-two.css
@@ -1,4 +1,4 @@
-@import url('media-query-two-blessed1.css');
+@import url('media-query-two-blessed1.css?z=d600730222ade09d92e438ed9334a616');
 
 @media print {
     #test { color: #090; }

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -35,7 +35,8 @@ var parser = {
             options: {
                 cleanup: true,
                 compress: false,
-                imports: true
+                imports: true,
+                cacheBuster: 'checksum'
             }
         }).parse(fs.readFileSync(path.join(__dirname, 'input', file), 'utf-8'), callback);
     }


### PR DESCRIPTION
Added option to use an MD5 checksum of the input file content as the cache buster hash. The timestamp will be used by default if the `cacheBuster` option is not specified as `'checksum'`.

Addresses #5
