### PR TITLE
Working tests, mocha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,14 +1,33 @@
 {
-  "name"            : "bless",
-  "description"     : "CSS Post-Processor",
-  "url"             : "http://blesscss.com",
-  "keywords"        : ["css", "parser", "bless", "less", "sass", "stylus"],
-  "author"          : "Paul Young <paulyoungonline+bless@gmail.com>",
-  "contributors"    : [],
-  "version"         : "3.0.3",
-  "bin"             : { "blessc": "./bin/blessc" },
-  "main"            : "./lib/bless/index",
-  "directories"     : { "test": "./test" },
-  "engines"         : { "node": ">=0.6.0" },
-  "devDependencies" : { "vows": "~0.6.2" }
+  "name": "bless",
+  "description": "CSS Post-Processor",
+  "url": "http://blesscss.com",
+  "keywords": [
+    "css",
+    "parser",
+    "bless",
+    "less",
+    "sass",
+    "stylus"
+  ],
+  "author": "Paul Young <paulyoungonline+bless@gmail.com>",
+  "contributors": [],
+  "version": "3.0.3",
+  "bin": {
+    "blessc": "./bin/blessc"
+  },
+  "scripts": {
+    "test": "./node_modules/mocha/bin/mocha"
+  },
+  "main": "./lib/bless/index",
+  "directories": {
+    "test": "./test"
+  },
+  "engines": {
+    "node": ">=0.6.0"
+  },
+  "devDependencies": {
+    "glob": "^4.0.6",
+    "mocha": "^2.0.1"
+  }
 }


### PR DESCRIPTION
Following from #46.

I was hoping to not do any major changes to get tests to run, but after running against the cryptic error messages from vows for a while, I switched the tests to mocha to get helpful errors.

I believe this also supports making the tests easier to reason about, because mocha avoids the magical context that vows uses (and requires), opting for variable scoping.

The package.json reformatting doesn't reflect my opinions - just the result of running npm install.