### PR TITLE
Added option to use a content hash as the cachebust string.

### DIFF
--- a/lib/bless/parser.js
+++ b/lib/bless/parser.js
@@ -2,6 +2,7 @@
 
 var path = require('path'),
     fs = require('fs'),
+    crypto = require('crypto'),
     bless = exports,
     cacheBuster = '?z=' + new Date().getTime();
 
@@ -92,7 +93,9 @@ bless.Parser = function Parser(env) {
             if (filesLength > 0 && options.imports) {
                 for(var k=1; k<=filesLength; k++) {
                     var outputFilename = filename + '-blessed' + k + ext;
-                    if (options.cacheBuster) {
+                    if (options.cacheBuster === 'hash') {
+                        outputFilename += '?z='+crypto.createHash('md5').update(files[k-1].content).digest('hex');
+                    } else if (options.cacheBuster) {
                         outputFilename += cacheBuster;
                     }
                     var importStr = '@import url(\'' + outputFilename + '\');';

--- a/test/cachebuster-test.js
+++ b/test/cachebuster-test.js
@@ -1,0 +1,28 @@
+var assert = require('assert'),
+    fs = require('fs'),
+    glob = require('glob'),
+    bless = require('../lib/bless'),
+    options = {
+        imports: true,
+        cacheBuster: 'hash'
+    },
+    imports = {
+        'test/input/above-limit.css': "@import url('above-limit-blessed2.css?z=6f9aa9cd206f0e64e49f65da8349015a');\n@import url('above-limit-blessed1.css?z=baa7e07769e537b0ba80c80ada8afd8f');",
+        'test/input/above-limit-with-comment.css': "@import url('above-limit-with-comment-blessed1.css?z=80420ee8477f060052cda65442358706');"
+    };
+
+describe('CacheBuster', function() {
+    glob.sync('test/input/above*.css').forEach(function(file){
+        it ("should parse "+file, function(done) {
+            var input = fs.readFileSync(file, 'utf-8'),
+                outputFile = file.replace('/input/', '/output/'),
+                parser = bless.Parser({output: outputFile, options: options});
+
+            parser.parse(input, function(error, files, numSelectors){
+                var blessedImports = files.reverse()[0].content;
+                assert.ok(blessedImports.indexOf(imports[file]) === 0);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
The test here is dependent on #47, but the feature is not. It seems the feature, if not the test, could be ported forward to 4.0.x.