### PR TITLE
Added customfilename option

### DIFF
--- a/lib/bless/parser.js
+++ b/lib/bless/parser.js
@@ -3,6 +3,7 @@
 var path = require('path'),
     fs = require('fs'),
     bless = exports,
+    customfilename = '-blessed',
     cacheBuster = '?z=' + new Date().getTime();
 
 bless.Parser = function Parser(env) {
@@ -10,6 +11,10 @@ bless.Parser = function Parser(env) {
     var output = this.env.output,
         options = this.env.options;
 
+    if(options.customfilename) {
+        customfilename = options.customfilename;
+    }
+    
     //
     // The Parser
     //
@@ -86,12 +91,12 @@ bless.Parser = function Parser(env) {
             var filesLength = files.length;
 
             for(var j=0; j<filesLength; j++) {
-                files[j]['filename'] = output.replace(ext, '-blessed' + (filesLength - j) + ext);
+                files[j]['filename'] = output.replace(ext, customfilename + (filesLength - j) + ext);
             }
 
             if (filesLength > 0 && options.imports) {
                 for(var k=1; k<=filesLength; k++) {
-                    var outputFilename = filename + '-blessed' + k + ext;
+                    var outputFilename = filename + customfilename + k + ext;
                     if (options.cacheBuster) {
                         outputFilename += cacheBuster;
                     }
@@ -119,7 +124,7 @@ bless.Parser.cleanup = function (options, output, callback) {
         dir = path.dirname(output),
         ext = path.extname(output),
         filename = path.basename(output, ext),
-        fileRegex = filename + '-blessed' + '(\\d+)' + ext;
+        fileRegex = filename + customfilename + '(\\d+)' + ext;
 
     if (options.cacheBuster) {
         fileRegex += cacheBuster;


### PR DESCRIPTION
This is an option to add a custom file name in the options and replace the hard-coded '-blessed'


When used with grunt-bless:

    bless: {
      css: {
        options: {
          'customfilename':'-whatever'
        },
        files: {
          'my-file-ie.css': 'my-file-input.css'
        }
      }
    }


would produce:

my-file-ie.css
my-file-ie-whatever1.css
my-file-ie-whatever2.css

instead of:

my-file-ie.css
my-file-ie-blessed1.css
my-file-ie-blessed2.css


I did not add this to command line options