### PR TITLE
Cache buster hash

### DIFF
--- a/lib/bless/parser.js
+++ b/lib/bless/parser.js
@@ -97,7 +97,7 @@ bless.Parser = function Parser(env) {
                     if (options.cacheBuster) {
                         outputFilename += cacheBusterParam;
                     }
-                    var importStr = '@import url(\'' + outputFilename + '\'); /*  */';
+                    var importStr = '@import url(\'' + outputFilename + '\');';
                     importStr = options.compress ? importStr : importStr + '\n';
                     rules.unshift(importStr);
                 }

--- a/lib/bless/parser.js
+++ b/lib/bless/parser.js
@@ -2,13 +2,15 @@
 
 var path = require('path'),
     fs = require('fs'),
+    crypto = require('crypto'),
     bless = exports,
-    cacheBuster = '?z=' + new Date().getTime();
+    cacheBusterTimestamp = new Date().getTime();
 
 bless.Parser = function Parser(env) {
     this.env = env = env || {};
     var output = this.env.output,
-        options = this.env.options;
+        options = this.env.options,
+        cacheBusterParam = options.cacheBusterParam ? ('?z=' + options.cacheBusterParam) : ('?z=' + cacheBusterTimestamp);
 
     //
     // The Parser
@@ -93,9 +95,9 @@ bless.Parser = function Parser(env) {
                 for(var k=1; k<=filesLength; k++) {
                     var outputFilename = filename + '-blessed' + k + ext;
                     if (options.cacheBuster) {
-                        outputFilename += cacheBuster;
+                        outputFilename += cacheBusterParam;
                     }
-                    var importStr = '@import url(\'' + outputFilename + '\');';
+                    var importStr = '@import url(\'' + outputFilename + '\'); /*  */';
                     importStr = options.compress ? importStr : importStr + '\n';
                     rules.unshift(importStr);
                 }
@@ -119,10 +121,11 @@ bless.Parser.cleanup = function (options, output, callback) {
         dir = path.dirname(output),
         ext = path.extname(output),
         filename = path.basename(output, ext),
-        fileRegex = filename + '-blessed' + '(\\d+)' + ext;
+        fileRegex = filename + '-blessed' + '(\\d+)' + ext,
+        cacheBusterParam = options.cacheBusterParam ? ('?z=' + options.cacheBusterParam) : ('?z=' + cacheBusterTimestamp);
 
     if (options.cacheBuster) {
-        fileRegex += cacheBuster;
+        fileRegex += cacheBusterParam;
     }
 
     var importRegex = '@import url\\(\'(' + fileRegex + '\')\\);';


### PR DESCRIPTION
Allows for any general cache buster parameter passed within options object from the caller, preferably a hash of content of the blessed file. Fallbacks to a timestamp if no parameter is passed.